### PR TITLE
可设置可选图片数量上限

### DIFF
--- a/JFImagePickerController/JFImagePickerController/JFAssetHelper.h
+++ b/JFImagePickerController/JFImagePickerController/JFAssetHelper.h
@@ -32,6 +32,7 @@
 @property (nonatomic, strong)   NSMutableArray			*defaultAssets;
 @property (nonatomic, strong)   NSString				*originStr;
 @property (nonatomic, strong)	ALAsset					*selectdAsset;
+@property (nonatomic, assign)   NSUInteger              maxImagesCount;
 
 + (JFAssetHelper *)sharedAssetHelper;
 

--- a/JFImagePickerController/JFImagePickerController/JFAssetHelper.m
+++ b/JFImagePickerController/JFImagePickerController/JFAssetHelper.m
@@ -335,4 +335,11 @@
     return _assetGroups[nIndex];
 }
 
+- (NSUInteger)maxImagesCount {
+    if (!_maxImagesCount) {
+        _maxImagesCount = 9;
+    }
+    return _maxImagesCount;
+}
+
 @end

--- a/JFImagePickerController/JFImagePickerController/JFImageCollectionViewController.h
+++ b/JFImagePickerController/JFImagePickerController/JFImageCollectionViewController.h
@@ -10,6 +10,8 @@
 
 @interface JFImageCollectionViewController : UIViewController
 
+@property (nonatomic, assign) NSInteger maxCount;
+
 - (UICollectionView *)collectionView;
 
 @end

--- a/JFImagePickerController/JFImagePickerController/JFImagePickerController.h
+++ b/JFImagePickerController/JFImagePickerController/JFImagePickerController.h
@@ -14,6 +14,7 @@
 
 - (JFImagePickerController *)initWithPreviewIndex:(NSInteger)index;
 @property (nonatomic, weak) id pickerDelegate;
+@property (nonatomic, assign) NSUInteger maxImagesCount;
 
 /**
  当退出编辑模式时需调用clear，用来清理内存，已选择照片的缓存

--- a/JFImagePickerController/JFImagePickerController/JFImagePickerController.m
+++ b/JFImagePickerController/JFImagePickerController/JFImagePickerController.m
@@ -72,12 +72,13 @@
 	UIBarButtonItem *rightFix = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace target:nil action:nil];
 	preview = [[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:self action:@selector(preview)];
 	UIBarButtonItem *fix = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
-	selectNum = [[UIBarButtonItem alloc] initWithTitle:@"0/9" style:UIBarButtonItemStylePlain target:nil action:nil];
+	selectNum = [[UIBarButtonItem alloc] initWithTitle:[NSString stringWithFormat:@"0/%ld", (unsigned long)ASSETHELPER.maxImagesCount] style:UIBarButtonItemStylePlain target:nil action:nil];
 	UIBarButtonItem *fix2 = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFlexibleSpace target:nil action:nil];
 	UIBarButtonItem *done = [[UIBarButtonItem alloc] initWithTitle:@"完成" style:UIBarButtonItemStylePlain target:self action:@selector(choiceDone)];
 	[toolbar setItems:@[leftFix, preview, fix, selectNum, fix2, done, rightFix]];
 	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(changeCount:) name:@"selectdPhotos" object:nil];
-	selectNum.title = [NSString stringWithFormat:@"%ld/9", (unsigned long)ASSETHELPER.selectdPhotos.count];
+	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(changeCount:) name:@"maxImagesCount" object:nil];
+	selectNum.title = [NSString stringWithFormat:@"%ld/%ld", (unsigned long)ASSETHELPER.selectdPhotos.count, (unsigned long)ASSETHELPER.maxImagesCount];
 }
 
 - (void)setLeftTitle:(NSString *)title{
@@ -89,7 +90,7 @@
 }
 
 - (void)changeCount:(NSNotification *)notifi{
-	selectNum.title = [NSString stringWithFormat:@"%ld/9", (unsigned long)ASSETHELPER.selectdPhotos.count];
+	selectNum.title = [NSString stringWithFormat:@"%ld/%ld", (unsigned long)ASSETHELPER.selectdPhotos.count, (unsigned long)ASSETHELPER.maxImagesCount];
 	if (![preview.title isEqualToString:@"取消"]) {
 		if (ASSETHELPER.selectdPhotos.count>0) {
 			preview.title = @"预览";
@@ -182,6 +183,12 @@
 
 - (BOOL)shouldAutorotate{
     return NO;
+}
+
+- (void)setMaxImagesCount:(NSUInteger)maxImagesCount {
+    _maxImagesCount = maxImagesCount;
+    [ASSETHELPER setMaxImagesCount:maxImagesCount];
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"maxImagesCount" object:nil];
 }
 
 @end

--- a/JFImagePickerController/JFImagePickerController/JFImagePickerViewCell.m
+++ b/JFImagePickerController/JFImagePickerController/JFImagePickerViewCell.m
@@ -77,7 +77,7 @@
 - (void)tapCell:(UITapGestureRecognizer *)tap{
 	CGPoint location = [tap locationInView:self];
 	if (CGRectContainsPoint(CGRectMake(placeholder.frame.origin.x-5, placeholder.frame.origin.y-5, placeholder.frame.size.width+10, placeholder.frame.size.height+10), location)) {
-		if (self.numOfSelect==nil&&ASSETHELPER.selectdPhotos.count>=9) {
+		if (self.numOfSelect==nil&&ASSETHELPER.selectdPhotos.count>=ASSETHELPER.maxImagesCount) {
 			return;
 		}
 		if (self.numOfSelect==nil) {


### PR DESCRIPTION
可能不止用于9图模式，比如想在修改头像的时候也用这个，就只需要上限为1。
使用方式如下：

```
- (void)preview:(UITapGestureRecognizer *)tap{
    UIView *temp = tap.view;
    JFImagePickerController *picker = [[JFImagePickerController alloc] initWithPreviewIndex:temp.tag];
    picker.maxImagesCount = 1;
    picker.pickerDelegate = self;
    [self presentViewController:picker animated:YES completion:nil];
}

- (void)pickPhotos{
    JFImagePickerController *picker = [[JFImagePickerController alloc] initWithRootViewController:nil];
    picker.maxImagesCount = 1;
    picker.pickerDelegate = self;
    [self presentViewController:picker animated:YES completion:nil];
}
```
